### PR TITLE
Add pack function

### DIFF
--- a/mnist/__init__.py
+++ b/mnist/__init__.py
@@ -1,3 +1,4 @@
 from .loader import MNIST
+from .packer import label_packer, data_packer
 
-__all__ = [MNIST, ]
+__all__ = [MNIST, label_packer, data_packer]

--- a/mnist/__init__.py
+++ b/mnist/__init__.py
@@ -1,4 +1,4 @@
 from .loader import MNIST
-from .packer import label_packer, data_packer
+from .packer import label_packer, img_packer
 
-__all__ = [MNIST, label_packer, data_packer]
+__all__ = [MNIST, label_packer, img_packer]

--- a/mnist/packer.py
+++ b/mnist/packer.py
@@ -1,0 +1,62 @@
+import gzip
+import os
+import struct
+
+
+def _binary_writter(data, filepath):
+    with open(filepath, 'wb') as file:
+        file.write(data)
+
+
+def _gzip_writter(data, filepath):
+    with gzip.open(filepath, 'wb') as file:
+        file.write(data)
+
+
+def data_packer(path, filename, imgs, gzip=False,
+                magic=2051, rows=28, cols=28):
+    data = b''
+    data += struct.pack(">IIII", magic, len(imgs), rows, cols)
+
+    to_list = list()
+    if type(imgs).__name__ == 'array':
+        to_list = list(imgs)
+    elif type(imgs).__name__ == 'ndarray':
+        to_list = list(imgs)
+    elif type(imgs).__name__ == 'list':
+        to_list = imgs
+    else:
+        raise TypeError('Unsupported data type.')
+
+    for i in to_list:
+        pack_format = '>' + 'B' * len(i)
+        data += struct.pack(pack_format, *i)
+
+    if gzip:
+        _gzip_writter(data, os.path.join(path, filename))
+    else:
+        _binary_writter(data, os.path.join(path, filename))
+
+
+def label_packer(path, filename, label,
+                 gzip=False, magic=2049):
+    data = b''
+    data += struct.pack(">II", magic, len(label))
+
+    to_list = list()
+    if type(label).__name__ == 'array':
+        to_list = list(label)
+    elif type(label).__name__ == 'ndarray':
+        to_list = list(label)
+    elif type(label).__name__ == 'list':
+        to_list = label
+    else:
+        raise TypeError('Unsupported label type.')
+
+    pack_format = '>' + 'B' * len(to_list)
+    data += struct.pack(pack_format, *to_list)
+
+    if gzip:
+        _gzip_writter(data, os.path.join(path, filename))
+    else:
+        _binary_writter(data, os.path.join(path, filename))

--- a/mnist/packer.py
+++ b/mnist/packer.py
@@ -13,8 +13,8 @@ def _gzip_writter(data, filepath):
         file.write(data)
 
 
-def data_packer(path, filename, imgs, gzip=False,
-                magic=2051, rows=28, cols=28):
+def img_packer(path, filename, imgs, gzip=False,
+               magic=2051, rows=28, cols=28):
     data = b''
     data += struct.pack(">IIII", magic, len(imgs), rows, cols)
 


### PR DESCRIPTION
In section EMNIST section of README, there is a suggestion that

> you should repack the data to avoid mirroring and rotation on each load

But repack function does not exists in this project, and here I have implement it. Here is an example shows how it works.

```python
>>> from mnist import MNIST
>>> from mnist import label_packer, img_packer
>>> mndata = MNIST('./mnist_data', gz=True)
>>> img, label = mndata.load_training()
>>> label_packer('.', 'test_out_label.gz', label, gzip=True)
>>> img_packer('.', 'test_out_img.gz', img, gzip=True)
```

Then there will be two new `.gz` files exist in `'.'` directory. Hope it helps.
ps. I put new functions in an individual file because the original file is called `loader.py` whoes name is far from what these functions actually do.