### PR TITLE
Expose repack from an executable

### DIFF
--- a/bin/emnist_repack
+++ b/bin/emnist_repack
@@ -32,9 +32,9 @@ if __name__ == '__main__':
     for dt_name in DATASETS:
         mn.select_emnist(dt_name)
 
-        tra_img, _ = mn.load_training()
-
         print("========procesing {} dataset========".format(dt_name))
+
+        tra_img, _ = mn.load_training()
         img_packer(dest, train_img_fname,
                    tra_img, gzip=True)
 

--- a/bin/emnist_repack
+++ b/bin/emnist_repack
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import argparse
+import os.path
+from mnist import MNIST
+from mnist import img_packer
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data", default="./emnist_data",
+                        help="Path to MNIST data dir")
+    parser.add_argument("--output", default=None,
+                        help="Where to save result")
+
+    args = parser.parse_args()
+
+    DATASETS = ["balanced", "byclass", "bymerge",
+                "digits", "letters", "mnist"]
+
+    mn = MNIST(args.data)
+
+    if not args.output:
+        dest = args.data
+        train_img_fname = 'rf_' + mn.train_img_fname
+        test_img_fname = 'rf_' + mn.test_img_fname
+    else:
+        dest = args.output
+        train_img_fname = mn.train_img_fname
+        test_img_fname = mn.test_img_fname
+
+    for dt_name in DATASETS:
+        mn.select_emnist(dt_name)
+
+        tra_img, _ = mn.load_training()
+
+        print("========procesing {} dataset========".format(dt_name))
+        img_packer(dest, train_img_fname,
+                   tra_img, gzip=True)
+
+        tes_img, _ = mn.load_testing()
+        img_packer(dest, test_img_fname,
+                   tes_img, gzip=True)


### PR DESCRIPTION
Sorry for no response to PR #21 . Although the previous one was merged but here I'd like to improve it following @sorki 's advice.

Here, the executable called `emnist_repack` takes two arguments, one for the emnist data and another is the output directory. If the `output` is not set, the program will write the output file into the original place but add `rf_` (stands for rotate fix) before it. Otherwise, files will be saved with same filename in the `output` directory. Also if anyone specify the `output` as same as `data`, I think he may want to override.